### PR TITLE
pin generators to a version that works with laravel 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"laravel/framework": "4.2.*",
         "fzaninotto/faker": "1.5.*@dev",
-        "way/generators": "dev-master"
+        "way/generators": "@stable"
 
 	},
 	"autoload": {


### PR DESCRIPTION
the dev-master version of way/generators requires Laravel 5.0
